### PR TITLE
Don't create bad types in type literal substituion in destructured arguments

### DIFF
--- a/type-generation/src/astToIR.ts
+++ b/type-generation/src/astToIR.ts
@@ -884,18 +884,20 @@ export class Converter {
       const name = prop.getName();
       const optional = !!prop.getQuestionTokenNode();
       // Try to get resolved type from the parameter type, fallback to interface definition
-      let type: TypeIR = this.typeToIR(prop.getTypeNode()!, optional);
       const propSymbol = paramType?.getProperty(name);
       if (!propSymbol) {
-        return type;
+        return this.typeToIR(prop.getTypeNode()!, optional);
       }
       const propType = propSymbol.getTypeAtLocation(lastParam!);
       // Convert the resolved type by getting a dummy type node
       // This is a bit hacky. Would be nice to create a synthetic node more
       // directly.
       const tempType = propType.getText();
-      if (tempType === prop.getTypeNode()?.getText()) {
-        return type;
+      if (
+        tempType.replaceAll(/\s/g, "") ===
+        prop.getTypeNode()?.getText().replaceAll(/\s/g, "")
+      ) {
+        return this.typeToIR(prop.getTypeNode()!, optional);
       }
 
       if (propType.isTypeParameter()) {
@@ -920,6 +922,7 @@ export class Converter {
       const typeAliasDecl = tempFile.getTypeAliases()[0];
       const dummyTypeNode = typeAliasDecl.getTypeNode()!;
       const res = this.typeToIR(dummyTypeNode, optional);
+      this.popNameContext();
       // Don't remove the temp file, it causes crashes. TODO: Fix this?
       return res;
     };

--- a/type-generation/tests/a.test.ts
+++ b/type-generation/tests/a.test.ts
@@ -1902,6 +1902,33 @@ describe("emit", () => {
         `).trim(),
       );
     });
+    it("type literal in destructured option arg", () => {
+      const res = emitFile(`
+        interface O<T> {
+          x?: { a: T; };
+        ;
+        declare function f(options: O<string>): void;
+      `);
+      assert.strictEqual(
+        removeTypeIgnores(res.slice(1).join("\n\n")),
+        dedent(`
+          @overload
+          def f(options: O_iface[str], /) -> None: ...
+
+          @overload
+          def f(*, x: f__Sig0_iface | None = None) -> None: ...
+
+          class O_iface[T](Protocol):
+              x: O_iface__x_iface | None = ...
+
+          class f__Sig0_iface(Protocol):
+              a: str = ...
+
+          class O_iface__x_iface(Protocol):
+              a: T = ...
+        `).trim(),
+      );
+    });
   });
   describe("adjustments", () => {
     it("setTimeout", () => {


### PR DESCRIPTION
In `getPropType()` we sometimes notice that there is a type param substitution so that the text of the
type of the prop node does not match the text of its definition node. In this case, we were calling
`typeToIR` twice and throwing away the first outcome. However, now `typeToIR()` can cause
side effects so we should make sure to only call it when we need the outcome.