### PR TITLE
Fix bug in sigToIRDestructure

### DIFF
--- a/type-generation/src/astToIR.ts
+++ b/type-generation/src/astToIR.ts
@@ -932,7 +932,6 @@ export class Converter {
       const typeAliasDecl = tempFile.getTypeAliases()[0];
       const dummyTypeNode = typeAliasDecl.getTypeNode()!;
       const res = this.typeToIR(dummyTypeNode, optional);
-      this.popNameContext();
       // Don't remove the temp file, it causes crashes. TODO: Fix this?
       return res;
     };


### PR DESCRIPTION
A stray popNameContext() causes some trouble