### PR TITLE
Use field in InterfaceIR to decide to inherit from Prototype/_JsObject

### DIFF
--- a/type-generation/src/astToIR.ts
+++ b/type-generation/src/astToIR.ts
@@ -128,6 +128,7 @@ export type InterfaceIR = {
   extraBases?: string[];
   // This is used to decide whether the class should be a Protocol or not.
   concrete?: boolean;
+  jsobject?: boolean;
   // Control how numbers are rendered in the class. Normally they are rendered
   // as int | float, but sometimes we just want it to be written as int.
   // This is handled in an adhoc manner in adjustInterfaceIR.
@@ -1175,6 +1176,7 @@ export class Converter {
       [],
       typeParams,
     );
+    concreteIR.jsobject = true;
     this.nameContext = undefined;
     return [ifaceIR, concreteIR];
   }
@@ -1278,7 +1280,9 @@ export class Converter {
       //
       // Otherwise it's a global namespace object?
       try {
-        return this.membersDeclarationToIR(name, typeNode, [], []);
+        const res = this.membersDeclarationToIR(name, typeNode, [], []);
+        res.jsobject = true;
+        return res;
       } catch (e) {
         console.warn(varDecl.getText());
         console.warn(getNodeLocation(varDecl));
@@ -1326,6 +1330,7 @@ export class Converter {
         [],
         typeParams,
       );
+      result.jsobject = true;
 
       this.ifaceTypeParamConstraints.clear();
 

--- a/type-generation/src/extract.ts
+++ b/type-generation/src/extract.ts
@@ -67,10 +67,10 @@ function fixupClassBases(nameToCls: Map<string, InterfaceIR>): void {
         }
       }
     }
-    if (cls.name.endsWith("_iface") && !cls.concrete) {
+    if (!cls.jsobject && !cls.concrete) {
       cls.extraBases.push("Protocol");
     }
-    if (!cls.name.endsWith("_iface")) {
+    if (cls.jsobject) {
       cls.extraBases.push("_JsObject");
     }
     cls.bases.sort(({ name: a }, { name: b }) => {

--- a/type-generation/tests/a.test.ts
+++ b/type-generation/tests/a.test.ts
@@ -472,7 +472,7 @@ describe("emit", () => {
       const res = emitFile("declare var a : boolean;");
       assert.strictEqual(removeTypeIgnores(res.at(-1)!), "a: bool = ...");
     });
-    it("extends", () => {
+    it("interface extends tests", () => {
       const res = emitFile(`
         interface B {
             b: number;


### PR DESCRIPTION
Rather than checking for the name to end in _iface