### PR TITLE
Prevent syntax error when keys are not Python identifiers

### DIFF
--- a/type-generation/src/astUtils.ts
+++ b/type-generation/src/astUtils.ts
@@ -272,3 +272,7 @@ export function classifyIdentifier(ident: Identifier): ClassifiedIdentifier {
   }
   throw new Error("Unrecognized ident!");
 }
+
+export function isValidPythonIdentifier(name: string): boolean {
+  return /^[a-zA-Z_$][a-zA-Z0-9_]*$/.test(name);
+}

--- a/type-generation/tests/a.test.ts
+++ b/type-generation/tests/a.test.ts
@@ -2003,6 +2003,25 @@ describe("emit", () => {
         `).trim(),
       );
     });
+    it("Type literal with keys that aren't identifiers", () => {
+      // Maybe we can do something with typed-dict for this? For now, just
+      // filter them out.
+      const res = emitFile(`
+        interface T {
+          "x-y": { x:  string; };
+        };
+        declare function f(): T;
+      `);
+      assert.strictEqual(
+        removeTypeIgnores(res.slice(1).join("\n\n")),
+        dedent(`
+          def f() -> T_iface: ...
+
+          class T_iface(Protocol):
+              pass
+        `).trim(),
+      );
+    });
   });
   it("inheriting from jsobject is also jsobject", () => {
     const res = emitFile(`


### PR DESCRIPTION
For now just filter these out.