### PR TITLE
Fix syntax error for weird spread parameters

### DIFF
--- a/type-generation/src/astToIR.ts
+++ b/type-generation/src/astToIR.ts
@@ -794,12 +794,11 @@ export class Converter {
         const optional = !!param.hasQuestionToken();
         let name = param.getName();
         let isIdentifier = isValidPythonIdentifier(name);
-        console.log({name, isIdentifier});
         const oldNameContext = this.nameContext?.slice();
         const paramType = param.getTypeNode()!;
         const isLast = idx === params.length - 1;
         const destructureOnly = isLast && Node.isTypeLiteral(paramType);
-        if (!destructureOnly) {
+        if (!destructureOnly && !isIdentifier) {
           // Replace name with args${idx}. This is an unfortunate case so we log it.
           console.log("Encountered argument with non identifier name");
           console.log(params[idx].print());

--- a/type-generation/tests/a.test.ts
+++ b/type-generation/tests/a.test.ts
@@ -2072,7 +2072,7 @@ describe("emit", () => {
         def f(*args0: tuple[()] | tuple[str]) -> None: ...
       `).trim(),
     );
-  })
+  });
   describe("adjustments", () => {
     it("setTimeout", () => {
       const res = emitIRNoTypeIgnores(convertBuiltinFunction("setTimeout"));


### PR DESCRIPTION
This output isn't correct, but at least it isn't a syntax error.

